### PR TITLE
Add aspect enum

### DIFF
--- a/lib/image_flux/option.rb
+++ b/lib/image_flux/option.rb
@@ -31,7 +31,12 @@ class ImageFlux::Option
   attribute :w, :integer, default: nil, aliases: %i[width]
   attribute :h, :integer, default: nil, aliases: %i[height]
   attribute :u, :boolean, default: true, aliases: %i[upscale]
-  attribute :a, :integer, default: 1, aliases: %i[aspect]
+  attribute :a, :integer, default: 1, aliases: %i[aspect], enum:{
+    scale: 0,
+    force_scale: 1,
+    crop: 2,
+    pad: 3
+  }
   attribute :c, :integer_array, default: nil, aliases: %i[crop]
   attribute :cr, :float_array, default: nil, aliases: %i[]
   attribute :g, :integer, default: 4, aliases: %i[gravity], enum: {

--- a/spec/image_flux/option_spec.rb
+++ b/spec/image_flux/option_spec.rb
@@ -3,11 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe ImageFlux::Option do
-  subject(:option) { described_class.new(width: 100, o: false, f: 'png') }
+  subject(:option) { described_class.new(width: 100, o: false, f: 'png', a: :crop) }
 
   describe '#to_query' do
     subject(:to_query) { option.to_query }
 
-    it { is_expected.to eq('w=100,o=0,f=png') }
+    it { is_expected.to eq('w=100,o=0,f=png,a=2') }
   end
 end


### PR DESCRIPTION
https://console.imageflux.jp/docs/#conversion_parameters

```
出力画像のアスペクトモードを設定します。
0: (scale) 入力画像のアスペクト比に合わせ、出力画像の幅、高さにおさまるようにする
1: (force-scale) 入力画像のアスペクト比を無視し、出力画像の幅、高さに合わせる
2: (crop) 出力画像の幅、高さを満たすように縮小し、はみ出た領域をクロップする
3: (pad) 入力画像のアスペクト比に合わせ、埋まらなかった部分を指定した背景色で埋める
```