### PR TITLE
Fix warnings

### DIFF
--- a/lib/image_flux/option.rb
+++ b/lib/image_flux/option.rb
@@ -14,7 +14,7 @@ class ImageFlux::Option
   end
 
   def self.attribute(name, type, options = {}, &block)
-    attribute = ImageFlux::Attribute.new(name, type, options)
+    attribute = ImageFlux::Attribute.new(name, type, **options)
     attribute.instance_eval(&block) if block_given?
     key_pairs[attribute.name] = attribute
     attribute.aliases.each do |key|


### PR DESCRIPTION
Fix #10

To fix warnings, it uses `**`-splat instead.